### PR TITLE
[BUGFIX] Return unique id value when it has to be re-created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/.idea

--- a/src/Helpers/CreateShortUrlHelper.php
+++ b/src/Helpers/CreateShortUrlHelper.php
@@ -45,8 +45,9 @@ class CreateShortUrlHelper
 
         if($links->contains($string)) {
             $string = str_random(8);
-        } else {
-            return $string;
         }
+
+        return $string;
+
     }
 }


### PR DESCRIPTION
The function unique_id only returned the value when the unique string was not already taken.
If a new unique_id has to be generated no return was done
Also seupt the .gitignore file for phpstorm config